### PR TITLE
Update of snap for bcd tag v0.2.5

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: bookmark-cd
 base: core20
-version: ':snap_version'
+version: 'v0.2.5'
 summary: bcd is a way to cd to directories that have been bookmarked.
 description: |
   bcd is a way to cd to directories that have been bookmarked.
@@ -17,7 +17,7 @@ plugs:
 parts:
   bookmark-cd:
     plugin: rust
-    source: https://github.com/a1ecbr0wn/bcd/archive/refs/tags/:snap_version.tar.gz
+    source: https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.5.tar.gz
 
 apps:
   bookmark-cd:


### PR DESCRIPTION
Update snap for v0.2.5
- Change to version number
- Change of source file link
- Auto-generated by workflow