### PR TITLE
Update of snap for bcd tag v0.2.10

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ title: bookmark-cd
 name: bookmark-cd
 type: app
 base: core20
-version: 'v0.2.9'
+version: 'v0.2.10'
 summary: bcd to a bookmarked directory
 description: |
   `bcd` is a way to cd to directories that have been bookmarked.
@@ -32,7 +32,7 @@ plugs:
 parts:
   bookmark-cd:
     plugin: rust
-    source: https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.9.tar.gz
+    source: https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.10.tar.gz
 
 apps:
   bookmark-cd:


### PR DESCRIPTION
Update snap for v0.2.10
- Change to version number
- Change of source file link
- Auto-generated by workflow