### PR TITLE
Update of snap for bcd tag v1.1.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ title: bookmark-cd
 name: bookmark-cd
 type: app
 base: core24
-version: "v1.0.29"
+version: "v1.1.0"
 summary: bcd to a bookmarked directory
 description: |
   `bcd` is a way to cd to directories that have been bookmarked.
@@ -41,7 +41,7 @@ plugs:
 parts:
   bookmark-cd:
     plugin: rust
-    source: https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.29.tar.gz
+    source: https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.1.0.tar.gz
 
 apps:
   bookmark-cd:


### PR DESCRIPTION
Update snap for v1.1.0
- Change to version number
- Change of source file link
- Auto-generated by workflow